### PR TITLE
Fix `websocket: close 1006 (abnormal closure): unexpected EOF` errors when calling `binance.WsCombinedBookTickerServe()`

### DIFF
--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -18,8 +18,10 @@ var (
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
+	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
+	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
-	WebsocketKeepalive = false
+	WebsocketKeepalive = true
 	// UseTestnet switch all the WS streams from production to the testnet
 	UseTestnet = false
 	ProxyUrl   = ""

--- a/v2/futures/websocket.go
+++ b/v2/futures/websocket.go
@@ -87,19 +87,26 @@ func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
 	lastResponse := time.Now()
-	c.SetPongHandler(func(msg string) error {
+
+	c.SetPingHandler(func(pingData string) error {
+		// Respond with Pong using the server's PING payload
+		err := c.WriteControl(
+			websocket.PongMessage,
+			[]byte(pingData),
+			time.Now().Add(time.Second*10), // Short deadline to ensure timely response
+		)
+		if err != nil {
+			return err
+		}
+
 		lastResponse = time.Now()
+
 		return nil
 	})
 
 	go func() {
 		defer ticker.Stop()
 		for {
-			deadline := time.Now().Add(10 * time.Second)
-			err := c.WriteControl(websocket.PingMessage, []byte{}, deadline)
-			if err != nil {
-				return
-			}
 			<-ticker.C
 			if time.Since(lastResponse) > timeout {
 				c.Close()

--- a/v2/futures/websocket.go
+++ b/v2/futures/websocket.go
@@ -93,7 +93,7 @@ func keepAlive(c *websocket.Conn, timeout time.Duration) {
 		err := c.WriteControl(
 			websocket.PongMessage,
 			[]byte(pingData),
-			time.Now().Add(time.Second*10), // Short deadline to ensure timely response
+			time.Now().Add(WebsocketPongTimeout), // Short deadline to ensure timely response
 		)
 		if err != nil {
 			return err

--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -25,7 +25,7 @@ var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
-	WebsocketKeepalive = false
+	WebsocketKeepalive = true
 	// UseTestnet switch all the WS streams from production to the testnet
 	UseTestnet = false
 	// WebsocketTimeoutReadWriteConnection is an interval for sending ping/pong messages if WebsocketKeepalive is enabled

--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -24,6 +24,8 @@ var (
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
+	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
+	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
 	WebsocketKeepalive = true
 	// UseTestnet switch all the WS streams from production to the testnet

--- a/v2/options/websocket.go
+++ b/v2/options/websocket.go
@@ -88,19 +88,26 @@ func keepAlive(c *websocket.Conn, timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
 	lastResponse := time.Now()
-	c.SetPongHandler(func(msg string) error {
+
+	c.SetPingHandler(func(pingData string) error {
+		// Respond with Pong using the server's PING payload
+		err := c.WriteControl(
+			websocket.PongMessage,
+			[]byte(pingData),
+			time.Now().Add(time.Second*10), // Short deadline to ensure timely response
+		)
+		if err != nil {
+			return err
+		}
+
 		lastResponse = time.Now()
+
 		return nil
 	})
 
 	go func() {
 		defer ticker.Stop()
 		for {
-			deadline := time.Now().Add(10 * time.Second)
-			err := c.WriteControl(websocket.PingMessage, []byte{}, deadline)
-			if err != nil {
-				return
-			}
 			<-ticker.C
 			if time.Since(lastResponse) > timeout {
 				c.Close()

--- a/v2/options/websocket.go
+++ b/v2/options/websocket.go
@@ -94,7 +94,7 @@ func keepAlive(c *websocket.Conn, timeout time.Duration) {
 		err := c.WriteControl(
 			websocket.PongMessage,
 			[]byte(pingData),
-			time.Now().Add(time.Second*10), // Short deadline to ensure timely response
+			time.Now().Add(WebsocketPongTimeout), // Short deadline to ensure timely response
 		)
 		if err != nil {
 			return err

--- a/v2/options/websocket_service.go
+++ b/v2/options/websocket_service.go
@@ -19,6 +19,8 @@ const (
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
+	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
+	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
 	WebsocketKeepalive = true
 	// UseTestnet switch all the WS streams from production to the testnet

--- a/v2/options/websocket_service.go
+++ b/v2/options/websocket_service.go
@@ -20,7 +20,7 @@ var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
-	WebsocketKeepalive = false
+	WebsocketKeepalive = true
 	// UseTestnet switch all the WS streams from production to the testnet
 	UseTestnet = false
 

--- a/v2/websocket.go
+++ b/v2/websocket.go
@@ -54,9 +54,11 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 		// websocket.Conn.ReadMessage or when the stopC channel is
 		// closed by the client.
 		defer close(doneC)
-		if WebsocketKeepalive {
-			keepAlive(c, WebsocketTimeout)
-		}
+
+		// This function overwrites the default ping frame handler
+		// sent by ther server
+		keepAlive(c)
+
 		// Wait for the stopC channel to be closed.  We do that in a
 		// separate goroutine because ReadMessage is a blocking
 		// operation.
@@ -83,30 +85,20 @@ var wsServe = func(cfg *WsConfig, handler WsHandler, errHandler ErrHandler) (don
 	return
 }
 
-func keepAlive(c *websocket.Conn, timeout time.Duration) {
-	ticker := time.NewTicker(timeout)
-
-	lastResponse := time.Now()
-	c.SetPongHandler(func(msg string) error {
-		lastResponse = time.Now()
+func keepAlive(c *websocket.Conn) {
+	// Set handler to reply to server Pings with Pongs containing the same payload
+	c.SetPingHandler(func(pingData string) error {
+		// Respond with Pong using the server's Ping payload
+		err := c.WriteControl(
+			websocket.PongMessage,
+			[]byte(pingData),
+			time.Now().Add(time.Second*10), // Short deadline to ensure timely response
+		)
+		if err != nil {
+			c.Close()
+		}
 		return nil
 	})
-
-	go func() {
-		defer ticker.Stop()
-		for {
-			deadline := time.Now().Add(10 * time.Second)
-			err := c.WriteControl(websocket.PingMessage, []byte{}, deadline)
-			if err != nil {
-				return
-			}
-			<-ticker.C
-			if time.Since(lastResponse) > timeout {
-				c.Close()
-				return
-			}
-		}
-	}()
 }
 
 var WsGetReadWriteConnection = func(cfg *WsConfig) (*websocket.Conn, error) {

--- a/v2/websocket.go
+++ b/v2/websocket.go
@@ -97,7 +97,7 @@ func keepAlive(c *websocket.Conn, timeout time.Duration) {
 		err := c.WriteControl(
 			websocket.PongMessage,
 			[]byte(pingData),
-			time.Now().Add(time.Second*10), // Short deadline to ensure timely response
+			time.Now().Add(WebsocketPongTimeout), // Short deadline to ensure timely response
 		)
 		if err != nil {
 			return err

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -18,6 +18,11 @@ var (
 	BaseWsApiMainURL       = "wss://ws-api.binance.com:443/ws-api/v3"
 	BaseWsApiTestnetURL    = "wss://testnet.binance.vision/ws-api/v3"
 
+	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
+	WebsocketTimeout = time.Second * 60
+
+	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
+	WebsocketKeepalive = false
 	// WebsocketTimeoutReadWriteConnection is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	// using for websocket API (read/write)
 	WebsocketTimeoutReadWriteConnection = time.Second * 10

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -18,11 +18,6 @@ var (
 	BaseWsApiMainURL       = "wss://ws-api.binance.com:443/ws-api/v3"
 	BaseWsApiTestnetURL    = "wss://testnet.binance.vision/ws-api/v3"
 
-	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
-	WebsocketTimeout = time.Second * 60
-
-	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
-	WebsocketKeepalive = false
 	// WebsocketTimeoutReadWriteConnection is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	// using for websocket API (read/write)
 	WebsocketTimeoutReadWriteConnection = time.Second * 10

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -20,7 +20,8 @@ var (
 
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	WebsocketTimeout = time.Second * 60
-
+	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
+	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
 	WebsocketKeepalive = true
 	// WebsocketTimeoutReadWriteConnection is an interval for sending ping/pong messages if WebsocketKeepalive is enabled

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -22,7 +22,7 @@ var (
 	WebsocketTimeout = time.Second * 60
 
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability
-	WebsocketKeepalive = false
+	WebsocketKeepalive = true
 	// WebsocketTimeoutReadWriteConnection is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
 	// using for websocket API (read/write)
 	WebsocketTimeoutReadWriteConnection = time.Second * 10


### PR DESCRIPTION
I implemented this fix according to Binance Websocket General information to avoid  `websocket: close 1006 (abnormal closure): unexpected EOF` errors:

```text
The websocket server will send a ping frame every 20 seconds.
If the websocket server does not receive a pong frame back from the connection within a minute the connection will be disconnected.
When you receive a ping, you must send a pong with a copy of ping's payload as soon as possible.
Unsolicited pong frames are allowed, but will not prevent disconnection. It is recommended that the payload for these pong frames are empty.
```

https://github.com/bnb-chain/websocket/blob/78bda6652e7166759b9f2ed92b4d4c67352bfbab/conn.go#L794