### PR TITLE
Do not close ws conn from client side.

### DIFF
--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -17,7 +17,7 @@ var (
 
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
-	WebsocketTimeout = time.Second * 60
+	WebsocketTimeout = time.Second * 600
 	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
 	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability

--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -23,7 +23,7 @@ var (
 
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
-	WebsocketTimeout = time.Second * 60
+	WebsocketTimeout = time.Second * 600
 	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
 	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability

--- a/v2/options/websocket_service.go
+++ b/v2/options/websocket_service.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
-	WebsocketTimeout = time.Second * 60
+	WebsocketTimeout = time.Second * 600
 	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
 	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -19,7 +19,7 @@ var (
 	BaseWsApiTestnetURL    = "wss://testnet.binance.vision/ws-api/v3"
 
 	// WebsocketTimeout is an interval for sending ping/pong messages if WebsocketKeepalive is enabled
-	WebsocketTimeout = time.Second * 60
+	WebsocketTimeout = time.Second * 600
 	// WebsocketPongTimeout is an interval for sending a PONG frame in response to PING frame from server
 	WebsocketPongTimeout = time.Second * 10
 	// WebsocketKeepalive enables sending ping/pong messages to check the connection stability


### PR DESCRIPTION
Binance does not gurantee to send PING messages every 20s, currently it sends PING every 3m, we should not close ws conn with timeout less than the interval between binance sends PINGs. May increase this timeout or remove it in the future.