### PR TITLE
feat(dual_investment): Add dual investment service and related tests

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -428,11 +428,17 @@ type Client struct {
 	do         doFunc
 
 	UsedWeight UsedWeight
+	OrderCount OrderCount
 }
 
 type UsedWeight struct {
 	Used   int64
 	Used1M int64 // used in last 1 minute
+}
+
+type OrderCount struct {
+	Count10s int64
+	Count1d  int64
 }
 
 func (c *Client) debug(format string, v ...interface{}) {
@@ -540,6 +546,20 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	if usedWeight1M != "" {
 		if used, err := strconv.ParseInt(usedWeight1M, 10, 64); err == nil {
 			c.UsedWeight.Used1M = used
+		}
+	}
+
+	orderCount10s := res.Header.Get("X-Mbx-Order-Count-10s")
+	if orderCount10s != "" {
+		if count, err := strconv.ParseInt(orderCount10s, 10, 64); err == nil {
+			c.OrderCount.Count10s = count
+		}
+	}
+
+	orderCount1d := res.Header.Get("X-Mbx-Order-Count-1d")
+	if orderCount1d != "" {
+		if count, err := strconv.ParseInt(orderCount1d, 10, 64); err == nil {
+			c.OrderCount.Count1d = count
 		}
 	}
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -425,6 +426,13 @@ type Client struct {
 	Logger     *log.Logger
 	TimeOffset int64
 	do         doFunc
+
+	UsedWeight UsedWeight
+}
+
+type UsedWeight struct {
+	Used   int64
+	Used1M int64 // used in last 1 minute
 }
 
 func (c *Client) debug(format string, v ...interface{}) {
@@ -521,6 +529,20 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 	if err != nil {
 		return []byte{}, err
 	}
+
+	usedWeight := res.Header.Get("X-Mbx-Used-Weight")
+	if usedWeight != "" {
+		if used, err := strconv.ParseInt(usedWeight, 10, 64); err == nil {
+			c.UsedWeight.Used = used
+		}
+	}
+	usedWeight1M := res.Header.Get("X-Mbx-Used-Weight-1m")
+	if usedWeight1M != "" {
+		if used, err := strconv.ParseInt(usedWeight1M, 10, 64); err == nil {
+			c.UsedWeight.Used1M = used
+		}
+	}
+
 	data, err = io.ReadAll(res.Body)
 	if err != nil {
 		return []byte{}, err
@@ -1403,3 +1425,7 @@ func (c *Client) NewSimpleEarnService() *SimpleEarnService {
 }
 
 // ----- end simple earn service -----
+
+func (c *Client) NewDualInvestmentService() *DualInvestmentService {
+	return &DualInvestmentService{c: c}
+}

--- a/v2/dual_investment_service.go
+++ b/v2/dual_investment_service.go
@@ -1,0 +1,362 @@
+package binance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type DualInvestmentService struct {
+	c *Client
+}
+
+func (s DualInvestmentService) ListProductService() *ListDualInvestmentProductService {
+	return &ListDualInvestmentProductService{c: s.c}
+}
+
+func (s DualInvestmentService) ListPositionService() *ListDualInvestmentPositionService {
+	return &ListDualInvestmentPositionService{c: s.c}
+}
+
+func (s DualInvestmentService) GetAccountService() *GetDualInvestmentAccountsService {
+	return &GetDualInvestmentAccountsService{c: s.c}
+}
+
+func (s DualInvestmentService) SubscribeService() *SubscribeDualInvestmentService {
+	return &SubscribeDualInvestmentService{c: s.c}
+}
+
+func (s DualInvestmentService) EditAutoCompoundStatusService() *EditAutoCompoundStatusDualInvestmentService {
+	return &EditAutoCompoundStatusDualInvestmentService{c: s.c}
+}
+
+// ---------------------------------------------------------------
+type DualInvestmentOptionType string
+
+const (
+	DualInvestmentOptionTypeCall DualInvestmentOptionType = "CALL"
+	DualInvestmentOptionTypePut  DualInvestmentOptionType = "PUT"
+)
+
+type ListDualInvestmentProductService struct {
+	c             *Client
+	optionType    DualInvestmentOptionType
+	exercisedCoin string
+	investCoin    string
+
+	pageSize  *int
+	pageIndex *int
+}
+
+type DualInvestmentProductListResponse struct {
+	Total int                     `json:"total"`
+	List  []DualInvestmentProduct `json:"list"`
+}
+
+type DualInvestmentProduct struct {
+	ID                   string                   `json:"id"`
+	InvestCoin           string                   `json:"investCoin"`
+	ExercisedCoin        string                   `json:"exercisedCoin"`
+	StrikePrice          string                   `json:"strikePrice"`
+	Duration             int                      `json:"duration"`
+	SettleDate           int64                    `json:"settleDate"`
+	PurchaseDecimal      int                      `json:"purchaseDecimal"`
+	PurchaseEndTime      int64                    `json:"purchaseEndTime"`
+	CanPurchase          bool                     `json:"canPurchase"`
+	APR                  string                   `json:"apr"`
+	OrderID              int64                    `json:"orderId"`
+	MinAmount            string                   `json:"minAmount"`
+	MaxAmount            string                   `json:"maxAmount"`
+	CreateTimestamp      int64                    `json:"createTimestamp"`
+	OptionType           DualInvestmentOptionType `json:"optionType"`
+	IsAutoCompoundEnable bool                     `json:"isAutoCompoundEnable"`
+	AutoCompoundPlanList []string                 `json:"autoCompoundPlanList"`
+}
+
+func (s *ListDualInvestmentProductService) OptionType(optionType DualInvestmentOptionType) *ListDualInvestmentProductService {
+	s.optionType = optionType
+	return s
+}
+func (s *ListDualInvestmentProductService) ExercisedCoin(exercisedCoin string) *ListDualInvestmentProductService {
+	s.exercisedCoin = exercisedCoin
+	return s
+}
+func (s *ListDualInvestmentProductService) InvestCoin(investCoin string) *ListDualInvestmentProductService {
+	s.investCoin = investCoin
+	return s
+}
+func (s *ListDualInvestmentProductService) PageSize(pageSize int) *ListDualInvestmentProductService {
+	if pageSize < 1 {
+		pageSize = 10
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	s.pageSize = &pageSize
+	return s
+}
+func (s *ListDualInvestmentProductService) PageIndex(pageIndex int) *ListDualInvestmentProductService {
+	if pageIndex < 1 {
+		pageIndex = 1
+	}
+	s.pageIndex = &pageIndex
+	return s
+}
+
+func (s *ListDualInvestmentProductService) Do(ctx context.Context, opts ...RequestOption) (res *DualInvestmentProductListResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/dci/product/list",
+		secType:  secTypeSigned,
+	}
+	r.setParam("optionType", s.optionType)
+	r.setParam("exercisedCoin", s.exercisedCoin)
+	r.setParam("investCoin", s.investCoin)
+	if s.pageSize != nil {
+		r.setParam("pageSize", *s.pageSize)
+	}
+	if s.pageIndex != nil {
+		r.setParam("pageIndex", *s.pageIndex)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(DualInvestmentProductListResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type ListDualInvestmentPositionStatus string
+
+const (
+	ListDualInvestmentPositionStatusPending         ListDualInvestmentPositionStatus = "PENDING"
+	ListDualInvestmentPositionStatusPurchaseSuccess ListDualInvestmentPositionStatus = "PURCHASE_SUCCESS"
+	ListDualInvestmentPositionStatusSettled         ListDualInvestmentPositionStatus = "SETTLED"
+	ListDualInvestmentPositionStatusPurchaseFail    ListDualInvestmentPositionStatus = "PURCHASE_FAIL"
+	ListDualInvestmentPositionStatusRefunding       ListDualInvestmentPositionStatus = "REFUNDING"
+	ListDualInvestmentPositionStatusRefundSuccess   ListDualInvestmentPositionStatus = "REFUND_SUCCESS"
+	ListDualInvestmentPositionStatusSettling        ListDualInvestmentPositionStatus = "SETTLING"
+)
+
+type ListDualInvestmentPositionService struct {
+	c         *Client
+	status    *ListDualInvestmentPositionStatus
+	pageSize  *int
+	pageIndex *int
+}
+
+type ListDualInvestmentPositionResponse struct {
+	Total int                          `json:"total"`
+	List  []ListDualInvestmentPosition `json:"list"`
+}
+type ListDualInvestmentPosition struct {
+	ID                 string                           `json:"id"`
+	InvestCoin         string                           `json:"investCoin"`
+	ExercisedCoin      string                           `json:"exercisedCoin"`
+	SubscriptionAmount string                           `json:"subscriptionAmount"`
+	StrikePrice        string                           `json:"strikePrice"`
+	Duration           int                              `json:"duration"`
+	SettleDate         int64                            `json:"settleDate"`
+	PurchaseStatus     ListDualInvestmentPositionStatus `json:"purchaseStatus"`
+	APR                string                           `json:"apr"`
+	OrderID            int64                            `json:"orderId"`
+	PurchaseEndTime    int64                            `json:"purchaseEndTime"`
+	OptionType         DualInvestmentOptionType         `json:"optionType"`
+	AutoCompoundPlan   DualInvestmentCompoundPlan       `json:"autoCompoundPlan"`
+}
+
+func (s *ListDualInvestmentPositionService) Status(status ListDualInvestmentPositionStatus) *ListDualInvestmentPositionService {
+	s.status = &status
+	return s
+}
+
+func (s *ListDualInvestmentPositionService) PageSize(pageSize int) *ListDualInvestmentPositionService {
+	if pageSize < 1 {
+		pageSize = 10
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	s.pageSize = &pageSize
+	return s
+}
+func (s *ListDualInvestmentPositionService) PageIndex(pageIndex int) *ListDualInvestmentPositionService {
+	if pageIndex < 1 {
+		pageIndex = 1
+	}
+	s.pageIndex = &pageIndex
+	return s
+}
+
+func (s *ListDualInvestmentPositionService) Do(ctx context.Context, opts ...RequestOption) (res *ListDualInvestmentPositionResponse, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/dci/product/positions",
+		secType:  secTypeSigned,
+	}
+	if s.status != nil {
+		r.setParam("status", *s.status)
+	}
+	if s.pageSize != nil {
+		r.setParam("pageSize", *s.pageSize)
+	}
+	if s.pageIndex != nil {
+		r.setParam("pageIndex", *s.pageIndex)
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(ListDualInvestmentPositionResponse)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type GetDualInvestmentAccountsService struct {
+	c *Client
+}
+
+type GetDualInvestmentAccountsResp struct {
+	TotalAmountInBTC  string `json:"totalAmountInBTC"`
+	TotalAmountInUSDT string `json:"totalAmountInUSDT"`
+}
+
+func (s *GetDualInvestmentAccountsService) Do(ctx context.Context, opts ...RequestOption) (res *GetDualInvestmentAccountsResp, err error) {
+	r := &request{
+		method:   http.MethodGet,
+		endpoint: "/sapi/v1/dci/product/accounts",
+		secType:  secTypeSigned,
+	}
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(GetDualInvestmentAccountsResp)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type DualInvestmentCompoundPlan string
+
+const (
+	DualInvestmentCompoundPlanNone     DualInvestmentCompoundPlan = "NONE"     // disable auto compound
+	DualInvestmentCompoundPlanStandard DualInvestmentCompoundPlan = "STANDARD" // basic plan
+	DualInvestmentCompoundPlanAdvanced DualInvestmentCompoundPlan = "ADVANCED" // advance plan
+)
+
+type SubscribeDualInvestmentService struct {
+	c                *Client
+	id               string
+	orderId          int64
+	depositAmount    string
+	autoCompoundPlan DualInvestmentCompoundPlan
+}
+
+type SubscribeDualInvestmentResp struct {
+	PositionID         int64                            `json:"positionId"`
+	InvestCoin         string                           `json:"investCoin"`
+	ExercisedCoin      string                           `json:"exercisedCoin"`
+	SubscriptionAmount string                           `json:"subscriptionAmount"`
+	Duration           int                              `json:"duration"`
+	AutoCompoundPlan   DualInvestmentCompoundPlan       `json:"autoCompoundPlan"` // 自动复投计划，当为NONE时不显示
+	StrikePrice        string                           `json:"strikePrice"`
+	SettleDate         int64                            `json:"settleDate"`
+	PurchaseStatus     ListDualInvestmentPositionStatus `json:"purchaseStatus"`
+	APR                string                           `json:"apr"`
+	OrderID            int64                            `json:"orderId"`
+	PurchaseTime       int64                            `json:"purchaseTime"`
+	OptionType         DualInvestmentOptionType         `json:"optionType"`
+}
+
+func (s *SubscribeDualInvestmentService) ID(id string) *SubscribeDualInvestmentService {
+	s.id = id
+	return s
+}
+
+func (s *SubscribeDualInvestmentService) OrderID(orderId int64) *SubscribeDualInvestmentService {
+	s.orderId = orderId
+	return s
+}
+
+func (s *SubscribeDualInvestmentService) DepositAmount(depositAmount string) *SubscribeDualInvestmentService {
+	s.depositAmount = depositAmount
+	return s
+}
+
+func (s *SubscribeDualInvestmentService) AutoCompoundPlan(autoCompoundPlan DualInvestmentCompoundPlan) *SubscribeDualInvestmentService {
+	s.autoCompoundPlan = autoCompoundPlan
+	return s
+}
+
+func (s *SubscribeDualInvestmentService) Do(ctx context.Context, opts ...RequestOption) (res *SubscribeDualInvestmentResp, err error) {
+	r := &request{
+		method:   http.MethodPost,
+		endpoint: "/sapi/v1/dci/product/subscribe",
+		secType:  secTypeSigned,
+	}
+	r.setParam("id", s.id)
+	r.setParam("orderId", s.orderId)
+	r.setParam("depositAmount", s.depositAmount)
+	r.setParam("autoCompoundPlan", s.autoCompoundPlan)
+
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(SubscribeDualInvestmentResp)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type EditAutoCompoundStatusDualInvestmentService struct {
+	c                *Client
+	positionId       string
+	autoCompoundPlan DualInvestmentCompoundPlan
+}
+type EditAutoCompoundStatusDualInvestmentResp struct {
+	PositionID       int64                      `json:"positionId"`
+	AutoCompoundPlan DualInvestmentCompoundPlan `json:"autoCompoundPlan"`
+}
+
+func (s *EditAutoCompoundStatusDualInvestmentService) PositionID(positionID string) *EditAutoCompoundStatusDualInvestmentService {
+	s.positionId = positionID
+	return s
+}
+func (s *EditAutoCompoundStatusDualInvestmentService) AutoCompoundPlan(plan DualInvestmentCompoundPlan) *EditAutoCompoundStatusDualInvestmentService {
+	s.autoCompoundPlan = plan
+	return s
+}
+
+func (s *EditAutoCompoundStatusDualInvestmentService) Do(ctx context.Context, opts ...RequestOption) (res *EditAutoCompoundStatusDualInvestmentResp, err error) {
+	r := &request{
+		method:   http.MethodPost,
+		endpoint: "/sapi/v1/dci/product/auto_compound/edit-status",
+		secType:  secTypeSigned,
+	}
+	r.setParam("positionId", s.positionId)
+	r.setParam("AutoCompoundPlan", s.autoCompoundPlan)
+
+	data, err := s.c.callAPI(ctx, r, opts...)
+	if err != nil {
+		return nil, err
+	}
+	res = new(EditAutoCompoundStatusDualInvestmentResp)
+	err = json.Unmarshal(data, res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/v2/dual_investment_service.go
+++ b/v2/dual_investment_service.go
@@ -103,6 +103,7 @@ func (s *ListDualInvestmentProductService) PageIndex(pageIndex int) *ListDualInv
 	return s
 }
 
+// https://developers.binance.com/docs/dual_investment/quick-start
 func (s *ListDualInvestmentProductService) Do(ctx context.Context, opts ...RequestOption) (res *DualInvestmentProductListResponse, err error) {
 	r := &request{
 		method:   http.MethodGet,

--- a/v2/dual_investment_service_test.go
+++ b/v2/dual_investment_service_test.go
@@ -1,0 +1,256 @@
+package binance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type dualInvestmentServiceTestSuite struct {
+	baseTestSuite
+}
+
+func TestDualInvestmentService(t *testing.T) {
+	suite.Run(t, new(dualInvestmentServiceTestSuite))
+}
+
+func (s *dualInvestmentServiceTestSuite) TestListProducts() {
+	data := []byte(`{
+    "total": 1,
+    "list": [
+        {
+            "id": "741590",
+            "investCoin": "USDT",
+            "exercisedCoin": "BNB",
+            "strikePrice": "380",
+            "duration": 4,
+            "settleDate": 1709020800000,
+            "purchaseDecimal": 8,
+            "purchaseEndTime": 1708934400000,
+            "canPurchase": true, 
+            "apr": "0.6076",
+            "orderId": 8257205859,
+            "minAmount": "0.1",
+            "maxAmount": "25265.7",
+            "createTimestamp": 1708560084000,
+            "optionType": "PUT",
+            "isAutoCompoundEnable": true, 
+            "autoCompoundPlanList": [
+                "STANDARD",
+                "ADVANCE"
+            ]
+        }
+    ]
+}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"optionType":    "PUT",
+			"exercisedCoin": "BNB",
+			"investCoin":    "USDT",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	resp, err := s.client.NewDualInvestmentService().
+		ListProductService().
+		InvestCoin("USDT").
+		ExercisedCoin("BNB").
+		OptionType(DualInvestmentOptionTypePut).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Equal(1, len(resp.List))
+	s.assertProduct(&DualInvestmentProduct{
+		ID:                   "741590",
+		InvestCoin:           "USDT",
+		ExercisedCoin:        "BNB",
+		StrikePrice:          "380",
+		Duration:             4,
+		SettleDate:           1709020800000,
+		PurchaseDecimal:      8,
+		PurchaseEndTime:      1708934400000,
+		CanPurchase:          true,
+		APR:                  "0.6076",
+		OrderID:              8257205859,
+		MinAmount:            "0.1",
+		MaxAmount:            "25265.7",
+		CreateTimestamp:      1708560084000,
+		OptionType:           DualInvestmentOptionTypePut,
+		IsAutoCompoundEnable: true,
+		AutoCompoundPlanList: []string{"STANDARD", "ADVANCE"},
+	}, &resp.List[0])
+}
+
+func (s *dualInvestmentServiceTestSuite) TestSubscribe() {
+	data := []byte(`{
+		"positionId": 10208824,
+		"investCoin": "BNB",
+		"exercisedCoin": "USDT",
+		"subscriptionAmount": "0.002",
+		"duration": 4,
+		"autoCompoundPlan": "STANDARD",
+		"strikePrice": "380",
+		"settleDate": 1709020800000,
+		"purchaseStatus": "PURCHASE_SUCCESS",
+		"apr": "0.7397",
+		"orderId": 8259117597,
+		"purchaseTime": 1708677583874,
+		"optionType": "CALL"
+	}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"id":               "10208824",
+			"orderId":          8259117597,
+			"depositAmount":    "0.002",
+			"autoCompoundPlan": "STANDARD",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	resp, err := s.client.NewDualInvestmentService().
+		SubscribeService().
+		ID("10208824").
+		OrderID(8259117597).
+		DepositAmount("0.002").
+		AutoCompoundPlan(DualInvestmentCompoundPlanStandard).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Equal(int64(10208824), resp.PositionID)
+	r.Equal("BNB", resp.InvestCoin)
+	r.Equal("USDT", resp.ExercisedCoin)
+	r.Equal("0.002", resp.SubscriptionAmount)
+	r.Equal(4, resp.Duration)
+	r.Equal(DualInvestmentCompoundPlanStandard, resp.AutoCompoundPlan)
+	r.Equal("380", resp.StrikePrice)
+	r.Equal(int64(1709020800000), resp.SettleDate)
+	r.Equal(ListDualInvestmentPositionStatusPurchaseSuccess, resp.PurchaseStatus)
+	r.Equal("0.7397", resp.APR)
+	r.Equal(int64(8259117597), resp.OrderID)
+	r.Equal(int64(1708677583874), resp.PurchaseTime)
+	r.Equal(DualInvestmentOptionTypeCall, resp.OptionType)
+}
+
+func (s *dualInvestmentServiceTestSuite) TestListPositions() {
+	data := []byte(`{
+    "total": 1,
+    "list": [
+        {
+            "id": "10160533",
+            "investCoin": "USDT",
+            "exercisedCoin": "BNB",
+            "subscriptionAmount": "0.5",
+            "strikePrice": "330",
+            "duration": 4,
+            "settleDate": 1708416000000,
+            "purchaseStatus": "PURCHASE_SUCCESS",
+            "apr": "0.0365",
+            "orderId": 7973677530,
+            "purchaseEndTime": 1708329600000,
+            "optionType": "PUT",
+            "autoCompoundPlan": "STANDARD"
+        }
+    ]
+}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"status": "PURCHASE_SUCCESS",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	resp, err := s.client.NewDualInvestmentService().
+		ListPositionService().
+		Status(ListDualInvestmentPositionStatusPurchaseSuccess).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Equal(1, len(resp.List))
+	r.Equal("10160533", resp.List[0].ID)
+	r.Equal("USDT", resp.List[0].InvestCoin)
+	r.Equal("BNB", resp.List[0].ExercisedCoin)
+	r.Equal("0.5", resp.List[0].SubscriptionAmount)
+	r.Equal("330", resp.List[0].StrikePrice)
+	r.Equal(4, resp.List[0].Duration)
+	r.Equal(int64(1708416000000), resp.List[0].SettleDate)
+	r.Equal(ListDualInvestmentPositionStatusPurchaseSuccess, resp.List[0].PurchaseStatus)
+	r.Equal("0.0365", resp.List[0].APR)
+	r.Equal(int64(7973677530), resp.List[0].OrderID)
+	r.Equal(int64(1708329600000), resp.List[0].PurchaseEndTime)
+	r.Equal(DualInvestmentOptionTypePut, resp.List[0].OptionType)
+	r.Equal(DualInvestmentCompoundPlanStandard, resp.List[0].AutoCompoundPlan)
+}
+
+func (s *dualInvestmentServiceTestSuite) TestGetAccounts() {
+	data := []byte(`{
+   "totalAmountInBTC": "0.01067982",   
+   "totalAmountInUSDT": "77.13289230" 
+}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{})
+		s.assertRequestEqual(e, r)
+	})
+
+	resp, err := s.client.NewDualInvestmentService().
+		GetAccountService().
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Equal("0.01067982", resp.TotalAmountInBTC)
+	r.Equal("77.13289230", resp.TotalAmountInUSDT)
+}
+
+func (s *dualInvestmentServiceTestSuite) TestEditAutoCompoundStatus() {
+	data := []byte(`{
+    "positionId": 123456789,
+    "autoCompoundPlan":"ADVANCED"
+}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"positionId":       "123456789",
+			"AutoCompoundPlan": "ADVANCED",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	resp, err := s.client.NewDualInvestmentService().
+		EditAutoCompoundStatusService().
+		PositionID("123456789").
+		AutoCompoundPlan(DualInvestmentCompoundPlanAdvanced).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Equal(int64(123456789), resp.PositionID)
+	r.Equal(DualInvestmentCompoundPlanAdvanced, resp.AutoCompoundPlan)
+}
+
+func (s *dualInvestmentServiceTestSuite) assertProduct(e, a *DualInvestmentProduct) {
+	r := s.r()
+	r.Equal(e.ID, a.ID)
+	r.Equal(e.InvestCoin, a.InvestCoin)
+	r.Equal(e.ExercisedCoin, a.ExercisedCoin)
+	r.Equal(e.StrikePrice, a.StrikePrice)
+	r.Equal(e.Duration, a.Duration)
+	r.Equal(e.SettleDate, a.SettleDate)
+	r.Equal(e.PurchaseDecimal, a.PurchaseDecimal)
+	r.Equal(e.PurchaseEndTime, a.PurchaseEndTime)
+	r.Equal(e.CanPurchase, a.CanPurchase)
+	r.Equal(e.APR, a.APR)
+	r.Equal(e.OrderID, a.OrderID)
+	r.Equal(e.MinAmount, a.MinAmount)
+	r.Equal(e.MaxAmount, a.MaxAmount)
+	r.Equal(e.CreateTimestamp, a.CreateTimestamp)
+	r.Equal(e.OptionType, a.OptionType)
+	r.Equal(e.IsAutoCompoundEnable, a.IsAutoCompoundEnable)
+	r.Equal(e.AutoCompoundPlanList, a.AutoCompoundPlanList)
+}

--- a/v2/futures/account_service_test.go
+++ b/v2/futures/account_service_test.go
@@ -46,7 +46,7 @@ func (s *accountServiceTestSuite) TestGetBalance() {
 		CrossUnPnl:         "0.00000000",
 		AvailableBalance:   "23.72469206",
 		MaxWithdrawAmount:  "23.72469206",
-		MarginAvailable:   true,
+		MarginAvailable:    true,
 		UpdateTime:         1617939110373,
 	}
 	s.assertBalanceEqual(e, res[0])


### PR DESCRIPTION
Added dual investment service including product listing, position listing, account information, subscription, and auto-compound status modification features. Also included corresponding test cases to ensure functionality correctness and stability.

https://developers.binance.com/docs/dual_investment/quick-start