### PR TITLE
fix: return res.Body.Close() error in callAPI()

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -590,7 +590,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		}
 		return nil, apiErr
 	}
-	return data, nil
+	return data, err
 }
 
 // SetApiEndpoint set api Endpoint

--- a/v2/delivery/client.go
+++ b/v2/delivery/client.go
@@ -353,7 +353,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		}
 		return nil, apiErr
 	}
-	return data, nil
+	return data, err
 }
 
 // SetApiEndpoint set api Endpoint

--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -395,7 +395,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		}
 		return nil, &res.Header, apiErr
 	}
-	return data, &res.Header, nil
+	return data, &res.Header, err
 }
 
 // SetApiEndpoint set api Endpoint

--- a/v2/options/client.go
+++ b/v2/options/client.go
@@ -370,7 +370,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		}
 		return nil, &res.Header, apiErr
 	}
-	return data, &res.Header, nil
+	return data, &res.Header, err
 }
 
 // SetApiEndpoint set api Endpoint

--- a/v2/portfolio/client.go
+++ b/v2/portfolio/client.go
@@ -447,7 +447,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		// Return the parsed error with the raw response included
 		return nil, &res.Header, NewErrorFromResponse(apiErr.Code, apiErr.Message, data)
 	}
-	return data, &res.Header, nil
+	return data, &res.Header, err
 }
 
 // SetApiEndpoint set api Endpoint

--- a/v2/portfolio_pro/client.go
+++ b/v2/portfolio_pro/client.go
@@ -218,7 +218,7 @@ func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption)
 		}
 		return nil, apiErr
 	}
-	return data, nil
+	return data, err
 }
 
 func (c *Client) NewMintBFUSDService() *MintBFUSDService {


### PR DESCRIPTION
If ```res.Body.Close()``` returns an error, it is silently ignored.

```Go
func (c *Client) callAPI(ctx context.Context, r *request, opts ...RequestOption) (data []byte, err error){
  ...
  defer func() {
      cerr := res.Body.Close()
      // Only overwrite the returned error if the original error was nil and an
      // error occurred while closing the body.
      if err == nil && cerr != nil {
	      err = cerr
      }
  }()
  ...
  return data, nil
}
```

