### PR TITLE
Add `subUserId` and `remark`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg/
 .idea
 *.iml
 coverage.txt
+vendor/

--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -334,6 +334,7 @@ type SubAccountList struct {
 type SubAccount struct {
 	SubUserID                   string `json:"subUserId"`
 	Email                       string `json:"email"`
+	Remark                      string `json:"remark"`
 	IsFreeze                    bool   `json:"isFreeze"`
 	CreateTime                  uint64 `json:"createTime"`
 	IsManagedSubAccount         bool   `json:"isManagedSubAccount"`

--- a/v2/subaccount_service.go
+++ b/v2/subaccount_service.go
@@ -332,6 +332,7 @@ type SubAccountList struct {
 }
 
 type SubAccount struct {
+	SubUserID                   string `json:"subUserId"`
 	Email                       string `json:"email"`
 	IsFreeze                    bool   `json:"isFreeze"`
 	CreateTime                  uint64 `json:"createTime"`


### PR DESCRIPTION
There's a `subUserId` and `remark` field.
Refer: https://developers.binance.com/docs/sub_account/account-management/Query-Sub-account-List

I verified also by manually printing out `data` in fie `client.go` - `callAPI`.