### PR TITLE
feat: accountInfoV2 parse isolatedWallet

### DIFF
--- a/v2/futures/account_service.go
+++ b/v2/futures/account_service.go
@@ -127,6 +127,7 @@ type AccountPosition struct {
 	Notional               string           `json:"notional"`
 	BidNotional            string           `json:"bidNotional"`
 	AskNotional            string           `json:"askNotional"`
+	IsolatedWallet         string           `json:"isolatedWallet"`
 	UpdateTime             int64            `json:"updateTime"`
 }
 


### PR DESCRIPTION
even though in https://developers.binance.com/docs/derivatives/usds-margined-futures/account/rest-api/Account-Information-V2 doesn't specify that `isolatedWallet` is returned with position information, in actual response it returns it like this

```
   {
            "symbol": "BTCUSDT",
            "initialMargin": "0",
            "maintMargin": "0",
            "unrealizedProfit": "0.00000000",
            "positionInitialMargin": "0",
            "openOrderInitialMargin": "0",
            "leverage": "5",
            "isolated": true,
            "entryPrice": "0.0",
            "breakEvenPrice": "0.0",
            "maxNotional": "480000000",
            "positionSide": "BOTH",
            "positionAmt": "0.000",
            "notional": "0",
            "isolatedWallet": "0", // we didn't parse this
            "updateTime": 1751517998423,
            "bidNotional": "0",
            "askNotional": "0"
        },
```

which I have tested with my account in isolated mode, and it returns the same number as in `PositionRisk`

