### PR TITLE
Added settlement fields to ListDualInvestmentPosition struct

### DIFF
--- a/v2/dual_investment_service.go
+++ b/v2/dual_investment_service.go
@@ -168,6 +168,12 @@ type ListDualInvestmentPosition struct {
 	PurchaseEndTime    int64                            `json:"purchaseEndTime"`
 	OptionType         DualInvestmentOptionType         `json:"optionType"`
 	AutoCompoundPlan   DualInvestmentCompoundPlan       `json:"autoCompoundPlan"`
+
+	// Settlement fields (only present for SETTLED positions)
+	SettlePrice  *string `json:"settlePrice,omitempty"`  // Actual market price at settlement
+	SettleAmount *string `json:"settleAmount,omitempty"` // Amount received after settlement
+	SettleAsset  *string `json:"settleAsset,omitempty"`  // Coin received (investCoin or exercisedCoin)
+	IsExercised  *bool   `json:"isExercised,omitempty"`  // Whether the option was exercised
 }
 
 func (s *ListDualInvestmentPositionService) Status(status ListDualInvestmentPositionStatus) *ListDualInvestmentPositionService {

--- a/v2/dual_investment_service_test.go
+++ b/v2/dual_investment_service_test.go
@@ -187,6 +187,74 @@ func (s *dualInvestmentServiceTestSuite) TestListPositions() {
 	r.Equal(DualInvestmentCompoundPlanStandard, resp.List[0].AutoCompoundPlan)
 }
 
+func (s *dualInvestmentServiceTestSuite) TestListPositionsSettled() {
+	data := []byte(`{
+    "total": 1,
+    "list": [
+        {
+            "id": "15653189",
+            "investCoin": "BTC",
+            "exercisedCoin": "FDUSD",
+            "subscriptionAmount": "0.00498",
+            "strikePrice": "120500",
+            "duration": 7,
+            "settleDate": 1758873600000,
+            "purchaseStatus": "SETTLED",
+            "apr": "0.1123",
+            "orderId": 37623188787,
+            "purchaseEndTime": 1758816000000,
+            "optionType": "CALL",
+            "autoCompoundPlan": "NONE",
+            "settlePrice": "109308.64",
+            "isExercised": false,
+            "settleAsset": "BTC",
+            "settleAmount": "0.00499045"
+        }
+    ]
+}`)
+	s.mockDo(data, nil)
+	defer s.assertDo()
+	s.assertReq(func(r *request) {
+		e := newSignedRequest().setParams(params{
+			"status": "SETTLED",
+		})
+		s.assertRequestEqual(e, r)
+	})
+
+	resp, err := s.client.NewDualInvestmentService().
+		ListPositionService().
+		Status(ListDualInvestmentPositionStatusSettled).
+		Do(newContext())
+	r := s.r()
+	r.NoError(err)
+	r.Equal(1, len(resp.List))
+
+	pos := resp.List[0]
+	r.Equal("15653189", pos.ID)
+	r.Equal("BTC", pos.InvestCoin)
+	r.Equal("FDUSD", pos.ExercisedCoin)
+	r.Equal("0.00498", pos.SubscriptionAmount)
+	r.Equal("120500", pos.StrikePrice)
+	r.Equal(7, pos.Duration)
+	r.Equal(int64(1758873600000), pos.SettleDate)
+	r.Equal(ListDualInvestmentPositionStatusSettled, pos.PurchaseStatus)
+	r.Equal("0.1123", pos.APR)
+	r.Equal(int64(37623188787), pos.OrderID)
+	r.Equal(int64(1758816000000), pos.PurchaseEndTime)
+	r.Equal(DualInvestmentOptionTypeCall, pos.OptionType)
+	r.Equal(DualInvestmentCompoundPlanNone, pos.AutoCompoundPlan)
+
+	// Assert settlement fields
+	r.NotNil(pos.SettlePrice)
+	r.Equal("109308.64", *pos.SettlePrice)
+	r.NotNil(pos.SettleAmount)
+	r.Equal("0.00499045", *pos.SettleAmount)
+	r.NotNil(pos.SettleAsset)
+	r.Equal("BTC", *pos.SettleAsset)
+	r.NotNil(pos.IsExercised)
+	r.Equal(false, *pos.IsExercised)
+}
+
 func (s *dualInvestmentServiceTestSuite) TestGetAccounts() {
 	data := []byte(`{
    "totalAmountInBTC": "0.01067982",   


### PR DESCRIPTION
To resolve https://github.com/ccxt/go-binance/issues/756

Adds four undocumented fields returned by the Binance API for settled dual investment positions:
- SettlePrice: Actual market price at settlement
- SettleAmount: Amount received after settlement
- SettleAsset: Coin received (investCoin or exercisedCoin)
- IsExercised: Whether the option was exercised

These fields are only present in API responses for positions with SETTLED status and are essential for
tracking settlement outcomes and calculating profits.