### PR TITLE
fix: websocket keepalive never sends pings; stabilize announcement stream

### DIFF
--- a/v2/common/websocket/client_test.go
+++ b/v2/common/websocket/client_test.go
@@ -3,10 +3,10 @@ package websocket
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log"
-	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,16 +37,10 @@ func TestClient(t *testing.T) {
 }
 
 func (s *clientTestSuite) TestReadWriteSync() {
-	stopCh := make(chan struct{})
-	readyCh := make(chan struct{})
-	go func() {
-		startWsTestServer(stopCh, readyCh)
-	}()
-	defer func() {
-		stopCh <- struct{}{}
-	}()
+	server := httptest.NewServer(http.HandlerFunc(wsHandler))
+	defer server.Close()
 
-	<-readyCh
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
 
 	conn, err := NewConnection(func() (*websocket.Conn, error) {
 		Dialer := websocket.Dialer{
@@ -55,7 +49,7 @@ func (s *clientTestSuite) TestReadWriteSync() {
 			EnableCompression: false,
 		}
 
-		c, _, err := Dialer.Dial("ws://localhost:8080/ws", nil)
+		c, _, err := Dialer.Dial(wsURL, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -233,34 +227,4 @@ func wsHandler(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-}
-
-func startWsTestServer(stopCh chan struct{}, readyCh chan struct{}) {
-	server := &http.Server{}
-
-	http.HandleFunc("/ws", wsHandler)
-	log.Println("WebSocket server started on :8080")
-
-	go func() {
-		lis, err := net.Listen("tcp", "localhost:8080")
-		if err != nil {
-			log.Fatalf("WebSocket server error: %v", err)
-		}
-		close(readyCh)
-
-		if err := server.Serve(lis); !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("WebSocket server error: %v", err)
-		}
-		log.Println("Stopped serving new connections.")
-	}()
-
-	<-stopCh
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if err := server.Shutdown(ctx); err != nil {
-		log.Fatalf("WebSocket shutdown error: %v", err)
-	}
-	log.Println("Graceful shutdown complete.")
 }

--- a/v2/websocket.go
+++ b/v2/websocket.go
@@ -109,8 +109,6 @@ var wsServeWithConnHandler = func(cfg *WsConfig, handler WsHandler, errHandler E
 // keepAliveWithPing Keepalive by actively sending ping messages
 func keepAliveWithPing(interval time.Duration, pongTimeout time.Duration) ConnHandler {
 	return func(ctx context.Context, c *websocket.Conn) {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
 
 		var lastResponse int64
 		atomic.StoreInt64(&lastResponse, time.Now().Unix())
@@ -119,19 +117,25 @@ func keepAliveWithPing(interval time.Duration, pongTimeout time.Duration) ConnHa
 			return nil
 		})
 
-		lastPongTicker := time.NewTicker(pongTimeout)
-		defer lastPongTicker.Stop()
-
 		go func() {
+			// pingTicker drives outgoing PING frames at the configured interval.
+			pingTicker := time.NewTicker(interval)
+			defer pingTicker.Stop()
+
+			// pongTimeoutTicker periodically checks that a PONG has been received
+			// within the timeout window; if not, the connection is presumed dead.
+			pongTimeoutTicker := time.NewTicker(pongTimeout)
+			defer pongTimeoutTicker.Stop()
+
 			for {
 				select {
 				case <-ctx.Done():
 					return
-				case <-ticker.C:
+				case <-pingTicker.C:
 					if err := c.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(WebsocketPingTimeout)); err != nil {
 						return
 					}
-				case <-lastPongTicker.C:
+				case <-pongTimeoutTicker.C:
 					if time.Since(time.Unix(atomic.LoadInt64(&lastResponse), 0)) > pongTimeout {
 						c.Close()
 						return
@@ -144,9 +148,6 @@ func keepAliveWithPing(interval time.Duration, pongTimeout time.Duration) ConnHa
 
 // keepAliveWithPong Keepalive by responding to ping messages
 func keepAliveWithPong(ctx context.Context, c *websocket.Conn, timeout time.Duration) {
-	ticker := time.NewTicker(timeout)
-	defer ticker.Stop()
-
 	var lastResponse int64
 	atomic.StoreInt64(&lastResponse, time.Now().Unix())
 
@@ -167,11 +168,15 @@ func keepAliveWithPong(ctx context.Context, c *websocket.Conn, timeout time.Dura
 	})
 
 	go func() {
+		// pingTimeoutTicker MUST live inside this goroutine; see keepAliveWithPing.
+		// Creating it in the outer function stops it immediately on return.
+		pingTimeoutTicker := time.NewTicker(timeout)
+		defer pingTimeoutTicker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
+			case <-pingTimeoutTicker.C:
 				if time.Since(time.Unix(atomic.LoadInt64(&lastResponse), 0)) > timeout {
 					c.Close()
 					return

--- a/v2/websocket_service.go
+++ b/v2/websocket_service.go
@@ -1161,22 +1161,33 @@ func WsAnnouncementServe(params WsAnnouncementParam, handler WsAnnouncementHandl
 			return
 		}
 
-		if event.Type != "DATA" {
-			errHandler(errors.New("type is not DATA: " + event.Type))
+		switch event.Type {
+		case "COMMAND":
+			switch event.Data {
+			case "SUCCESS":
+				return
+			default:
+				errHandler(errors.New("command failed: " + event.Data))
+				return
+			}
+		case "DATA":
+			switch event.Topic {
+			case "com_announcement_en":
+				e := new(WsAnnouncementEvent)
+				if err := json.Unmarshal([]byte(event.Data), &e); err != nil {
+					errHandler(err)
+					return
+				}
+				handler(e)
+			default:
+				errHandler(errors.New("unsupported topic: " + event.Topic))
+				return
+			}
+		default:
+			errHandler(errors.New("unsupported type: " + event.Type))
 			return
 		}
 
-		if event.Topic != "com_announcement_en" {
-			errHandler(errors.New("topic is not com_announcement_en: " + event.Topic))
-			return
-		}
-
-		e := new(WsAnnouncementEvent)
-		if err := json.Unmarshal([]byte(event.Data), &e); err != nil {
-			errHandler(err)
-			return
-		}
-		handler(e)
 	}
 	return wsServeWithConnHandler(cfg, wsHandler, errHandler, keepAliveWithPing(30*time.Second, WebsocketTimeout))
 }


### PR DESCRIPTION
This PR bundles three websocket fixes, all uncovered while investigating
why the announcement stream (`WsAnnouncementServe`) gets dropped by the
server every ~170s with `close 1006 (abnormal closure): unexpected EOF`.

## 1. fix: keepalive tickers were stopped before firing — pings never sent  *(root cause)*

`keepAliveWithPing` and `keepAliveWithPong` created their tickers in the
**outer returned closure** with `defer ticker.Stop()`:

```go
return func(ctx context.Context, c *websocket.Conn) {
    ticker := time.NewTicker(interval)
    defer ticker.Stop()                 // registered on the OUTER closure
    ...
    go func() { ... <-ticker.C ... }()  // goroutine launched
}                                       // closure returns here → defer fires → ticker.Stop()
```

The closure returns **immediately** after launching the goroutine, so
`defer ticker.Stop()` runs at once — the ticker is stopped before it can
ever fire. The goroutine's `select` is left with only `<-ctx.Done()`
reachable, therefore:

- `keepAliveWithPing`: **no PING is ever written** and the pong-timeout
  check never runs.
- `keepAliveWithPong`: the dead-connection monitor never fires (market
  streams still survive only because gorilla's default ping handler
  replies with pong inside `ReadMessage`).

This is exactly why the announcement stream — which uses
`keepAliveWithPing(30*time.Second, WebsocketTimeout)` — kept going down:
there was no heartbeat on the wire at all.

**Fix:** move both tickers *inside* the goroutine so their lifetime
matches the goroutine's, and rename them to make their roles explicit:
`pingTicker` / `pongTimeoutTicker` in `keepAliveWithPing`,
`pingTimeoutTicker` in `keepAliveWithPong`.

## 2. fix: handle COMMAND ack and route DATA by topic in announcement stream

`WsAnnouncementServe` treated any non-`DATA` message as an error, so the
`{"type":"COMMAND","data":"SUCCESS","subType":"REGISTER"}` registration
ack raised a spurious error on every connect. Switched to a
`COMMAND`/`DATA` switch that accepts the `SUCCESS` ack and dispatches
`DATA` by topic.

## 3. test: use httptest.NewServer instead of fixed port 8080

The websocket client test started a server on `localhost:8080`, which
made it fail (`bind: address already in use`) whenever the port was
taken. Replaced with `httptest.NewServer` (OS-assigned free port) and
removed the manual `startWsTestServer` helper.