### PR TITLE
Fix data race in websocket reconnect (handler mutation vs read) #800

### DIFF
--- a/v2/common/websocket/client.go
+++ b/v2/common/websocket/client.go
@@ -48,8 +48,8 @@ type messageId struct {
 type client struct {
 	Debug                       bool
 	logger                      *log.Logger
-	conn                        Connection
-	connMu                      sync.Mutex
+	conn                        atomic.Value // stores a Connection
+	connMu                      sync.Mutex   // serializes writes (Write/WriteSync)
 	reconnectSignal             chan struct{}
 	connectionEstablishedSignal chan struct{}
 	requestsList                RequestList
@@ -65,14 +65,13 @@ func (c *client) debug(format string, v ...any) {
 }
 
 func (c *client) Close() error {
-	return c.conn.Close()
+	return c.conn.Load().(Connection).Close()
 }
 
 // NewClient init client
 func NewClient(conn Connection) (Client, error) {
 	client := &client{
 		logger:                      log.New(os.Stderr, "Binance-golang ", log.LstdFlags),
-		conn:                        conn,
 		connMu:                      sync.Mutex{},
 		reconnectSignal:             make(chan struct{}, 1),
 		connectionEstablishedSignal: make(chan struct{}, 1),
@@ -80,6 +79,7 @@ func NewClient(conn Connection) (Client, error) {
 		readErrChan:                 make(chan error, 1),
 		readC:                       make(chan []byte),
 	}
+	client.conn.Store(conn)
 
 	go client.handleReconnect()
 	go client.read()
@@ -106,7 +106,7 @@ func (c *client) Write(id string, data []byte) error {
 		return ErrorWsIdAlreadySent
 	}
 
-	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+	if err := c.conn.Load().(Connection).WriteMessage(websocket.TextMessage, data); err != nil {
 		c.debug("write: unable to write message into websocket conn '%v'", err)
 		return err
 	}
@@ -122,7 +122,7 @@ func (c *client) WriteSync(id string, data []byte, timeout time.Duration) ([]byt
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
 
-	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+	if err := c.conn.Load().(Connection).WriteMessage(websocket.TextMessage, data); err != nil {
 		c.debug("write sync: unable to write message into websocket conn '%v'", err)
 		return nil, err
 	}
@@ -178,7 +178,8 @@ func (c *client) read() {
 
 	for {
 		c.debug("read: waiting for message")
-		_, message, err := c.conn.ReadMessage()
+		conn := c.conn.Load().(Connection)
+		_, message, err := conn.ReadMessage()
 		if err != nil {
 			c.debug("read: error reading message '%v'", err)
 			c.reconnectSignal <- struct{}{}
@@ -248,9 +249,10 @@ func (c *client) handleReconnect() {
 
 		b.Reset()
 
-		c.connMu.Lock()
-		c.conn = conn
-		c.connMu.Unlock()
+		// Swap the connection atomically so the concurrent reader
+		// (client.read) never observes a torn pointer. Written together
+		// with the synchronized reads in read()/Write()/WriteSync()/Close().
+		c.conn.Store(conn)
 
 		c.debug("reconnect: connected")
 		c.connectionEstablishedSignal <- struct{}{}
@@ -261,7 +263,7 @@ func (c *client) handleReconnect() {
 func (c *client) startReconnect(b *backoff.Backoff) Connection {
 	for {
 		atomic.AddInt64(&c.reconnectCount, 1)
-		conn, err := c.conn.RestoreConnection()
+		conn, err := c.conn.Load().(Connection).RestoreConnection()
 		if err != nil {
 			delay := b.Duration()
 			c.debug("reconnect: error while reconnecting. try in %s", delay.Round(time.Millisecond))
@@ -352,6 +354,16 @@ func NewConnection(
 	}
 
 	if isKeepAliveNeeded {
+		// Register the pong handler synchronously, before the read goroutine
+		// starts. Per the gorilla/websocket contract, connection handlers
+		// (SetPingHandler/SetPongHandler) must not be modified concurrently
+		// with reads; registering here (instead of inside the keepAlive
+		// goroutine) avoids the data race reported in
+		// https://github.com/ccxt/go-binance/issues/800.
+		wsConn.conn.SetPongHandler(func(msg string) error {
+			wsConn.updateLastResponse()
+			return nil
+		})
 		go wsConn.keepAlive(keepaliveTimeout)
 	}
 
@@ -398,11 +410,6 @@ func (c *connection) keepAlive(timeout time.Duration) {
 	ticker := time.NewTicker(timeout)
 
 	c.updateLastResponse()
-
-	c.conn.SetPongHandler(func(msg string) error {
-		c.updateLastResponse()
-		return nil
-	})
 
 	go func() {
 		defer ticker.Stop()

--- a/v2/common/websocket/client_test.go
+++ b/v2/common/websocket/client_test.go
@@ -228,3 +228,43 @@ func wsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 }
+
+// TestConnectionHandlerReadRace is a regression test for
+// https://github.com/ccxt/go-binance/issues/800. The keep-alive pong handler
+// used to be registered from the keepAlive goroutine, which raced with the
+// read loop calling ReadMessage on the same *websocket.Conn (both touch the
+// gorilla connection's handler fields). Run with -race: the buggy version is
+// caught by the race detector, the fixed version passes cleanly.
+func TestConnectionHandlerReadRace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(wsHandler))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	for i := 0; i < 10; i++ {
+		conn, err := NewConnection(func() (*websocket.Conn, error) {
+			Dialer := websocket.Dialer{
+				Proxy:             http.ProxyFromEnvironment,
+				HandshakeTimeout:  45 * time.Second,
+				EnableCompression: false,
+			}
+			c, _, err := Dialer.Dial(wsURL, nil)
+			if err != nil {
+				return nil, err
+			}
+			return c, nil
+		}, true, 10*time.Second)
+		if err != nil {
+			t.Fatalf("NewConnection: %v", err)
+		}
+
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"id":"race","method":"m"}`)); err != nil {
+			t.Fatalf("WriteMessage: %v", err)
+		}
+		// Concurrent read against the keepAlive goroutine that manages the
+		// connection handler.
+		_, _, _ = conn.ReadMessage()
+
+		_ = conn.Close()
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a data race detected by the Go race detector during websocket reconnects (#800).

## Root cause
The keep-alive pong handler was registered from inside the `keepAlive` goroutine (`connection.keepAlive`) via `c.conn.SetPongHandler(...)`, while the read loop (`client.read`) calls `c.conn.ReadMessage()` on the same `*websocket.Conn`. Per gorilla/websocket, connection handlers (`SetPingHandler`/`SetPongHandler`) must **not** be modified concurrently with reads; violating this produces the `advanceFrame` (read) vs `SetPongHandler` (write) race reported by `-race`.

Separately, the client connection pointer (`client.conn`) was assigned under `connMu` in `handleReconnect` while the read loop read it without the lock — a second, independent torn-pointer race.

## Fix
- Register the pong handler **synchronously in `NewConnection`**, before the read goroutine starts, so it is never mutated concurrently with reads.
- Replace the mutex-guarded `client.conn` field with `sync/atomic.Value`. Atomic load/store removes the torn-pointer race and — importantly — lets `client.read` read the connection without acquiring `connMu`, so it is no longer blocked behind `WriteSync` (which holds `connMu` for its whole lifetime). This avoids a regression where the reader could not observe responses.

## Test
- Added `TestConnectionHandlerReadRace`: starts a websocket server, opens a keep-alive connection, and reads concurrently with the keepalive goroutine. Run with `-race`; the buggy version is caught, the fixed version passes.
- `go test -race ./common/websocket/` passes, including the existing `TestClient` suite.

## Verification
```
go test -race -count=1 -run 'TestConnectionHandlerReadRace|TestClient' ./common/websocket/
# ok  github.com/adshao/go-binance/v2/common/websocket
```

Fixes #800.
