### PR TITLE
Fix MARGIN_CALL decode when position list 'p' is a JSON string (#687)

### DIFF
--- a/v2/delivery/websocket_service.go
+++ b/v2/delivery/websocket_service.go
@@ -674,7 +674,7 @@ type WsUserDataEvent struct {
 	Time                int64              `json:"E"`
 	Alias               string             `json:"i"`
 	CrossWalletBalance  string             `json:"cw"`
-	MarginCallPositions []WsPosition       `json:"p"`
+	MarginCallPositions WsPositionSlice    `json:"p"`
 	TransactionTime     int64              `json:"T"`
 	AccountUpdate       WsAccountUpdate    `json:"a"`
 	OrderTradeUpdate    WsOrderTradeUpdate `json:"o"`
@@ -685,10 +685,10 @@ func (e *WsUserDataEvent) UnmarshalJSON(data []byte) error {
 		Event               UserDataEventType  `json:"e"`
 		Time                any                `json:"E"`
 		Alias               string             `json:"i"`
-		CrossWalletBalance  string             `json:"cw"`
-		MarginCallPositions []WsPosition       `json:"p"`
-		TransactionTime     int64              `json:"T"`
-		AccountUpdate       WsAccountUpdate    `json:"a"`
+		CrossWalletBalance  string          `json:"cw"`
+		MarginCallPositions WsPositionSlice `json:"p"`
+		TransactionTime     int64           `json:"T"`
+		AccountUpdate       WsAccountUpdate `json:"a"`
 		OrderTradeUpdate    WsOrderTradeUpdate `json:"o"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
@@ -730,6 +730,23 @@ type WsBalance struct {
 	Balance            string `json:"wb"`
 	CrossWalletBalance string `json:"cw"`
 	BalanceChange      string `json:"bc"`
+}
+
+// WsPositionSlice is a slice of WsPosition that tolerates the exchange
+// occasionally sending the position list as a JSON string (e.g. "null" or "")
+// instead of an array on a MARGIN_CALL event. See issue #687.
+type WsPositionSlice []WsPosition
+
+func (s *WsPositionSlice) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		return nil
+	}
+	var positions []WsPosition
+	if err := json.Unmarshal(data, &positions); err != nil {
+		return err
+	}
+	*s = positions
+	return nil
 }
 
 // WsPosition define position

--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -1293,8 +1293,8 @@ type WsUserDataAccountUpdate struct {
 }
 
 type WsUserDataMarginCall struct {
-	CrossWalletBalance  string       `json:"cw"`
-	MarginCallPositions []WsPosition `json:"p"`
+	CrossWalletBalance  string          `json:"cw"`
+	MarginCallPositions WsPositionSlice `json:"p"`
 }
 
 type WsUserDataOrderTradeUpdate struct {
@@ -1367,6 +1367,27 @@ type WsBalance struct {
 	Balance            string `json:"wb"`
 	CrossWalletBalance string `json:"cw"`
 	ChangeBalance      string `json:"bc"`
+}
+
+// WsPositionSlice is a slice of WsPosition that tolerates the exchange
+// occasionally sending the position list as a JSON string (e.g. "null" or "")
+// instead of an array on a MARGIN_CALL event. The default json decoder would
+// fail with "cannot unmarshal string into Go struct field ... of type
+// []futures.WsPosition"; treating the string as an empty list keeps the stream
+// alive. See issue #687.
+type WsPositionSlice []WsPosition
+
+func (s *WsPositionSlice) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		// Server sent a string (e.g. "null") rather than an array.
+		return nil
+	}
+	var positions []WsPosition
+	if err := json.Unmarshal(data, &positions); err != nil {
+		return err
+	}
+	*s = positions
+	return nil
 }
 
 // WsPosition define position

--- a/v2/futures/websocket_service_test.go
+++ b/v2/futures/websocket_service_test.go
@@ -1720,9 +1720,51 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeMarginCall() {
 					IsolatedWallet:            "0",
 					MarkPrice:                 "187.17127",
 					UnrealizedPnL:             "-1.166074",
-					MaintenanceMarginRequired: "1.614445",
-				},
-			}},
+				MaintenanceMarginRequired: "1.614445",
+			},
+		}},
+	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+// TestWsUserDataServeMarginCallStringPositions reproduces issue #687: the
+// exchange sometimes sends the MARGIN_CALL position list `p` as a JSON string
+// (e.g. "null") instead of an array, which used to fail decoding with
+// "cannot unmarshal string into Go struct field .p of type []futures.WsPosition".
+func (s *websocketServiceTestSuite) TestWsUserDataServeMarginCallStringPositions() {
+	data := []byte(`{
+		"e":"MARGIN_CALL",
+		"E":1587727187525,
+		"cw":"3.16812045",
+		"p":"null"
+	}`)
+	expectedEvent := &WsUserDataEvent{
+		Event: "MARGIN_CALL",
+		Time:  1587727187525,
+		WsUserDataMarginCall: WsUserDataMarginCall{
+			CrossWalletBalance:  "3.16812045",
+			MarginCallPositions: nil,
+		},
+	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+// TestWsUserDataServeMarginCallEmptyStringPositions covers the case where `p`
+// is an empty JSON string rather than "null".
+func (s *websocketServiceTestSuite) TestWsUserDataServeMarginCallEmptyStringPositions() {
+	data := []byte(`{
+		"e":"MARGIN_CALL",
+		"E":1587727187525,
+		"cw":"3.16812045",
+		"p":""
+	}`)
+	expectedEvent := &WsUserDataEvent{
+		Event: "MARGIN_CALL",
+		Time:  1587727187525,
+		WsUserDataMarginCall: WsUserDataMarginCall{
+			CrossWalletBalance:  "3.16812045",
+			MarginCallPositions: nil,
+		},
 	}
 	s.testWsUserDataServe(data, expectedEvent)
 }

--- a/v2/portfolio/websocket_service.go
+++ b/v2/portfolio/websocket_service.go
@@ -74,8 +74,8 @@ type WsUserDataAccountUpdate struct {
 }
 
 type WsUserDataMarginCall struct {
-	CrossWalletBalance  string       `json:"cw"`
-	MarginCallPositions []WsPosition `json:"p"`
+	CrossWalletBalance  string          `json:"cw"`
+	MarginCallPositions WsPositionSlice `json:"p"`
 }
 
 type WsUserDataOrderTradeUpdate struct {
@@ -142,6 +142,23 @@ type WsBalance struct {
 	Balance            string `json:"wb"`
 	CrossWalletBalance string `json:"cw"`
 	ChangeBalance      string `json:"bc"`
+}
+
+// WsPositionSlice is a slice of WsPosition that tolerates the exchange
+// occasionally sending the position list as a JSON string (e.g. "null" or "")
+// instead of an array on a MARGIN_CALL event. See issue #687.
+type WsPositionSlice []WsPosition
+
+func (s *WsPositionSlice) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		return nil
+	}
+	var positions []WsPosition
+	if err := json.Unmarshal(data, &positions); err != nil {
+		return err
+	}
+	*s = positions
+	return nil
 }
 
 // WsPosition define position


### PR DESCRIPTION
## Summary

Fixes #687 — `futures.WsUserDataServe` occasionally returns an error:

```
json: cannot unmarshal string into Go struct field .p of type []futures.WsPosition
```

The exchange sometimes sends the `MARGIN_CALL` event's position list (`p`) as a JSON **string** (`"null"` or `""`) instead of an array. The default decoder fails on that, which tears down the user-data websocket stream.

## Changes

- Added a tolerant `WsPositionSlice` type with a custom `UnmarshalJSON` that treats a string value as an empty list (the field is non-essential for margin-call handling).
- Applied it to the `MarginCallPositions` (`json:"p"`) field in the futures, delivery and portfolio user-data event structs (identical schema, same bug class).
- Added regression tests for both the `"null"` and `""` cases.

## Verification

`go test ./futures/ ./delivery/ ./portfolio/` — all pass, including the two new tests that previously reproduced the decode error. `go build ./...` and `go vet` are clean.

Fixes #687
